### PR TITLE
minor bugfixes

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
@@ -266,6 +266,9 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
 
     // 💩💩💩 Define the AdvancedExpressionFoldingProvider extension point
     private static Expression getExpression(PsiElement element, @Nullable Document document, boolean createSynthetic) {
+        if (element == null) {
+            return null;
+        }
         if (element instanceof PsiForStatement) {
             Expression expression = getForStatementExpression((PsiForStatement) element, document);
             if (expression != null) {

--- a/src/com/intellij/advancedExpressionFolding/Function.java
+++ b/src/com/intellij/advancedExpressionFolding/Function.java
@@ -105,19 +105,21 @@ public abstract class Function extends Expression {
         if (operands.get(0).supportsFoldRegions(document, false)) {
             Collections.addAll(descriptors, operands.get(0).buildFoldRegions(element, document));
         }
-        TextRange commaOffset = TextRange.create(operands.get(0).getTextRange().getEndOffset(),
-                operands.get(1).getTextRange().getStartOffset());
-        if (operands.size() == 2 && ", ".equals(document.getText(commaOffset))) {
-            descriptors.add(new FoldingDescriptor(element.getNode(),
-                    commaOffset, group) {
-                @Nullable
-                @Override
-                public String getPlaceholderText() {
-                    return ", ";
+        if (operands.size() == 2) {
+            TextRange commaOffset = TextRange.create(operands.get(0).getTextRange().getEndOffset(),
+                    operands.get(1).getTextRange().getStartOffset());
+            if (", ".equals(document.getText(commaOffset))) {
+                descriptors.add(new FoldingDescriptor(element.getNode(),
+                        commaOffset, group) {
+                    @Nullable
+                    @Override
+                    public String getPlaceholderText() {
+                        return ", ";
+                    }
+                });
+                if (operands.get(1).supportsFoldRegions(document, false)) {
+                    Collections.addAll(descriptors, operands.get(1).buildFoldRegions(element, document));
                 }
-            });
-            if (operands.get(1).supportsFoldRegions(document, false)) {
-                Collections.addAll(descriptors, operands.get(1).buildFoldRegions(element, document));
             }
         }
         descriptors.add(new FoldingDescriptor(element.getNode(),


### PR DESCRIPTION
I was getting my environment working to try and fix my original problem reported in Issue-7 -- but in trying to recreate it I ran into another issue where the second operand was being accessed _before_ the check to see if there were two operands. It was a minor change made in your last commit.  I fixed that and then tried to recreate my original issue that I reported...but I couldn't.  Pretty confusing. I went ahead and added the guard for the null check so that even if by magic the getROperand returns null at least it wont blow up.  It looks like getExpression is already expected to possibly return null.  I have built and and running this version locally with no problems now.