### PR TITLE
Optimizations

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
@@ -23,6 +23,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.intellij.advancedExpressionFolding.PropertyUtil.guessPropertyName;
+
 public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
     private static final FoldingDescriptor[] NO_DESCRIPTORS = new FoldingDescriptor[0];
     private static final Pattern GENERICS_PATTERN = Pattern.compile("<[^<>]*>");
@@ -1824,29 +1826,6 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
 
     private static String charAt(@NotNull Document document, int position) {
         return document.getText(TextRange.create(position, position + 1));
-    }
-
-    @NotNull
-    private static String guessPropertyName(@NotNull String text) {
-        StringBuilder sb = new StringBuilder();
-        if (text.startsWith("get")) {
-            sb.append(text.substring(3));
-        } else if (text.startsWith("set")) {
-            sb.append(text.substring(3));
-        } else if (text.startsWith("is")) {
-            sb.append(text.substring(2));
-        } else {
-            sb.append(text);
-        }
-        for (int i = 0; i < sb.length(); i++) {
-            if (Character.isUpperCase(sb.charAt(i)) &&
-                    (i == sb.length() - 1 || Character.isUpperCase(sb.charAt(i + 1)) || i == 0)) {
-                sb.setCharAt(i, Character.toLowerCase(sb.charAt(i)));
-            } else if (Character.isLowerCase(sb.charAt(i))) {
-                break;
-            }
-        }
-        return sb.toString();
     }
 
     @Nullable

--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.intellij.advancedExpressionFolding.PropertyUtil.guessPropertyName;
+import static java.lang.Character.isWhitespace;
 
 public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
     private static final FoldingDescriptor[] NO_DESCRIPTORS = new FoldingDescriptor[0];
@@ -1791,10 +1792,10 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
                 position < document.getText().length()) {
             position += i;
             offset += i;
-            if (charAt(document, position).equals(".")) {
+            if (charAt(document, position) == '.') {
                 break;
             }
-            if (!charAt(document, position).matches("\\s")) {
+            if (!isWhitespace(charAt(document, position))) {
                 return Integer.MAX_VALUE;
             }
         }
@@ -1803,14 +1804,14 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
             do {
                 position += i;
                 offsetWithNewLine += i;
-                if (i < 0 && charAt(document, position).equals("\n")) {
+                if (i < 0 && charAt(document, position) == '\n') {
                     offset = offsetWithNewLine;
-                } else if (i > 0 && charAt(document, position).matches("\\s")) {
+                } else if (i > 0 && isWhitespace(charAt(document, position))) {
                     offset = offsetWithNewLine;
                 }
             } while (Math.abs(offsetWithNewLine) < 100 && position > 0 &&
                     position < document.getText().length() &&
-                    charAt(document, position).matches("\\s"));
+                    isWhitespace(charAt(document, position)));
         }
         if (Math.abs(offset) >= 100) {
             return Integer.MAX_VALUE;
@@ -1818,8 +1819,8 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
         return offset;
     }
 
-    private static String charAt(@NotNull Document document, int position) {
-        return document.getText(TextRange.create(position, position + 1));
+    private static char charAt(@NotNull Document document, int position) {
+        return document.getText(TextRange.create(position, position + 1)).charAt(0);
     }
 
     @Nullable

--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
@@ -733,7 +733,7 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
                                             && ((PsiReferenceExpression) e).isReferenceTo(r.resolve())
                                             || e instanceof PsiMethodCallExpression && ((PsiMethodCallExpression) e).getMethodExpression().isReferenceTo(r.resolve())
                             ).toList();
-                    if (references.size() > 0) {
+                    if (!references.isEmpty()) {
                         return new ElvisExpression(element, element.getTextRange(),
                                 getAnyExpression(element.getThenExpression(), document),
                                 getAnyExpression(element.getElseExpression(), document),
@@ -804,7 +804,7 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
                                         && ((PsiPostfixExpression) e).getOperand() instanceof PsiReferenceExpression
                                         && ((PsiReferenceExpression) ((PsiPostfixExpression) e).getOperand()).isReferenceTo(element)
                         ).toList();
-                if (references.size() == 0) {
+                if (references.isEmpty()) {
                     isFinal = true;
                 }
             }
@@ -1218,7 +1218,7 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
                                 break;
                             }
                         }
-                        if (flag && arguments.size() > 0) {
+                        if (flag && !arguments.isEmpty()) {
                             if (settings.getState().isGetExpressionsCollapse())
                                 return new SetLiteral(element, element.getTextRange(),
                                         TextRange.create(anonymousClass.getLBrace().getTextRange().getStartOffset(),

--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
@@ -339,15 +339,9 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
 
     @Contract("_, _, true -> !null")
     private static Expression getExpression(@NotNull PsiElement element, @NotNull Document document, boolean synthetic) {
-        if (synthetic) {
-            return CachedValuesManager.getCachedValue(element,
-                    () -> CachedValueProvider.Result.create(buildExpression(element, document, true),
-                            PsiModificationTracker.MODIFICATION_COUNT));
-        } else {
-            return CachedValuesManager.getCachedValue(element,
-                    () -> CachedValueProvider.Result.create(buildExpression(element, document, false),
-                            PsiModificationTracker.MODIFICATION_COUNT));
-        }
+        return CachedValuesManager.getCachedValue(element,
+                () -> CachedValueProvider.Result.create(buildExpression(element, document, synthetic),
+                        PsiModificationTracker.MODIFICATION_COUNT));
     }
 
     @SuppressWarnings("WeakerAccess")

--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.java
@@ -24,8 +24,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
-
     private static final FoldingDescriptor[] NO_DESCRIPTORS = new FoldingDescriptor[0];
+    private static final Pattern GENERICS_PATTERN = Pattern.compile("<[^<>]*>");
 
     private static Set<String> supportedMethods = new HashSet<String>() {
         {
@@ -1297,12 +1297,10 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
 
     @NotNull
     private static String eraseGenerics(@NotNull String signature) {
-        String re = "<[^<>]*>";
-        Pattern p = Pattern.compile(re);
-        Matcher m = p.matcher(signature);
+        Matcher m = GENERICS_PATTERN.matcher(signature);
         while (m.find()) {
             signature = m.replaceAll("");
-            m = p.matcher(signature);
+            m = GENERICS_PATTERN.matcher(signature);
         }
         return signature;
     }
@@ -1928,8 +1926,8 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
         try {
             @Nullable Expression expression = getNonSyntheticExpression(element, document);
             if (expression != null && expression.supportsFoldRegions(document, null)) {
-                allDescriptors = new ArrayList<>();
                 FoldingDescriptor[] descriptors = expression.buildFoldRegions(expression.getElement(), document, null);
+                allDescriptors = new ArrayList<>();
                 Collections.addAll(allDescriptors, descriptors);
             }
             if (expression == null || expression.isNested()) {
@@ -1939,12 +1937,11 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
                         if (allDescriptors == null) {
                             allDescriptors = new ArrayList<>();
                         }
-                        allDescriptors.addAll(Arrays.asList(descriptors));
+                        Collections.addAll(allDescriptors, descriptors);
                     }
                 }
             }
-        } catch (IndexNotReadyException e) {
-            // ignore
+        } catch (IndexNotReadyException ignore) {
         }
         return allDescriptors != null ? allDescriptors.toArray(NO_DESCRIPTORS) : NO_DESCRIPTORS;
     }
@@ -1971,4 +1968,5 @@ public class AdvancedExpressionFoldingBuilder extends FoldingBuilderEx {
         }
         return false;
     }
+
 }

--- a/src/com/intellij/advancedExpressionFolding/Expression.java
+++ b/src/com/intellij/advancedExpressionFolding/Expression.java
@@ -151,13 +151,13 @@ public abstract class Expression {
     }
 
     private static String map(String str, Map<Character, Character> subscriptMapping) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(str.length());
         for (int i = 0; i < str.length(); i++) {
             Character c = subscriptMapping.get(str.charAt(i));
             if (c == null) {
                 return null;
             } else if (!c.equals('❤')) {
-                sb.append(c);
+                sb.append((char) c);
             }
         }
         return sb.toString();

--- a/src/com/intellij/advancedExpressionFolding/InterpolatedString.java
+++ b/src/com/intellij/advancedExpressionFolding/InterpolatedString.java
@@ -102,12 +102,12 @@ public class InterpolatedString extends Expression {
                     ? operands.get(i + 1).getTextRange().getStartOffset() + 1
                     : operands.get(i + 1).getTextRange().getStartOffset();
             int fI = i;
-            StringBuilder sI = new StringBuilder().append(buf[0]);
+            StringBuilder sI = new StringBuilder(buf[0].length() + 2).append(buf[0]);
             if (!(operands.get(fI + 1) instanceof CharSequenceLiteral)) {
-                sI.append("$");
+                sI.append('$');
             }
             if (!(operands.get(fI + 1) instanceof Variable) && !(operands.get(fI + 1) instanceof CharSequenceLiteral)) {
-                sI.append("{");
+                sI.append('{');
                 buf[0] = "}";
             } else {
                 buf[0] = "";

--- a/src/com/intellij/advancedExpressionFolding/PropertyUtil.java
+++ b/src/com/intellij/advancedExpressionFolding/PropertyUtil.java
@@ -1,0 +1,29 @@
+package com.intellij.advancedExpressionFolding;
+
+import org.jetbrains.annotations.NotNull;
+
+public class PropertyUtil {
+
+    @NotNull
+    public static String guessPropertyName(@NotNull String text) {
+        StringBuilder sb = new StringBuilder();
+        if (text.startsWith("get")) {
+            sb.append(text.substring(3));
+        } else if (text.startsWith("set")) {
+            sb.append(text.substring(3));
+        } else if (text.startsWith("is")) {
+            sb.append(text.substring(2));
+        } else {
+            sb.append(text);
+        }
+        for (int i = 0; i < sb.length(); i++) {
+            if (Character.isUpperCase(sb.charAt(i)) &&
+                    (i == sb.length() - 1 || Character.isUpperCase(sb.charAt(i + 1)) || i == 0)) {
+                sb.setCharAt(i, Character.toLowerCase(sb.charAt(i)));
+            } else if (Character.isLowerCase(sb.charAt(i))) {
+                break;
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/PropertyUtil.java
+++ b/src/com/intellij/advancedExpressionFolding/PropertyUtil.java
@@ -2,25 +2,29 @@ package com.intellij.advancedExpressionFolding;
 
 import org.jetbrains.annotations.NotNull;
 
+import static java.lang.Character.isLowerCase;
+import static java.lang.Character.isUpperCase;
+import static java.lang.Character.toLowerCase;
+
 public class PropertyUtil {
 
     @NotNull
     public static String guessPropertyName(@NotNull String text) {
-        StringBuilder sb = new StringBuilder();
-        if (text.startsWith("get")) {
-            sb.append(text.substring(3));
-        } else if (text.startsWith("set")) {
-            sb.append(text.substring(3));
+        StringBuilder sb = new StringBuilder(text.length());
+        int startPos;
+        if (text.startsWith("get") || text.startsWith("set")) {
+            startPos = 3;
         } else if (text.startsWith("is")) {
-            sb.append(text.substring(2));
+            startPos = 2;
         } else {
-            sb.append(text);
+            startPos = 0;
         }
+        sb.append(text, startPos, text.length());
         for (int i = 0; i < sb.length(); i++) {
-            if (Character.isUpperCase(sb.charAt(i)) &&
-                    (i == sb.length() - 1 || Character.isUpperCase(sb.charAt(i + 1)) || i == 0)) {
-                sb.setCharAt(i, Character.toLowerCase(sb.charAt(i)));
-            } else if (Character.isLowerCase(sb.charAt(i))) {
+            if (isUpperCase(sb.charAt(i)) &&
+                    (i == sb.length() - 1 || isUpperCase(sb.charAt(i + 1)) || i == 0)) {
+                sb.setCharAt(i, toLowerCase(sb.charAt(i)));
+            } else if (isLowerCase(sb.charAt(i))) {
                 break;
             }
         }

--- a/src/com/intellij/advancedExpressionFolding/Range.java
+++ b/src/com/intellij/advancedExpressionFolding/Range.java
@@ -105,20 +105,13 @@ public class Range extends Expression {
     @Override
     public FoldingDescriptor[] buildFoldRegions(@NotNull PsiElement element, @NotNull Document document, @Nullable Expression parent) {
         FoldingGroup group = FoldingGroup.newGroup(getClass().getName());
-        StringBuilder sb1 = new StringBuilder().append(" ").append(separator).append(" ");
-        if (isStartInclusive()) {
-            sb1.append("[");
-        } else {
-            sb1.append("(");
-        }
-        String p1 = sb1.toString();
-        StringBuilder sb2 = new StringBuilder();
-        if (isEndInclusive()) {
-            sb2.append("]");
-        } else {
-            sb2.append(")");
-        }
-        String p2 = sb2.toString();
+        String p1 = new StringBuilder(separator.length() + 3)
+            .append(' ')
+            .append(separator)
+            .append(' ')
+            .append(isStartInclusive() ? '[' : '(')
+            .toString();
+        String p2 = isEndInclusive() ? "]" : ")";
         ArrayList<FoldingDescriptor> descriptors = new ArrayList<>();
         descriptors.add(new FoldingDescriptor(element.getNode(),
                 TextRange.create(getOperand().getTextRange().getEndOffset(),

--- a/test/com/intellij/advancedExpressionFolding/PropertyUtilTest.java
+++ b/test/com/intellij/advancedExpressionFolding/PropertyUtilTest.java
@@ -1,0 +1,20 @@
+package com.intellij.advancedExpressionFolding;
+
+import org.junit.Test;
+
+import static com.intellij.advancedExpressionFolding.PropertyUtil.guessPropertyName;
+import static org.junit.Assert.*;
+
+public class PropertyUtilTest {
+    @Test
+    public void testGuessPropertyName() {
+        assertEquals("", guessPropertyName(""));
+        assertEquals("length", guessPropertyName("length"));
+        assertEquals("name", guessPropertyName("getName"));
+        assertEquals("name", guessPropertyName("setName"));
+        assertEquals("enabled", guessPropertyName("isEnabled"));
+        assertEquals("enabledByDefault", guessPropertyName("isEnabledByDefault"));
+        assertEquals("html", guessPropertyName("getHTML"));
+        assertEquals("htmlText", guessPropertyName("isHTMLText"));
+    }
+}


### PR DESCRIPTION
Small micro optimizations mostly to avoid memory allocation:
1. create StringBuilder with initial capacity
2. use `StringBuilder.append(char)` instead of `.append(String)` or `.append(Object)`
etc