### PR TITLE
Do not process mouse events from editors in unrelated project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ intellij {
 }
 
 patchPluginXml {
-    untilBuild = "201.*"
+    untilBuild = "212.*"
 }
 
 apply plugin: 'java'
@@ -35,3 +35,5 @@ repositories {
     maven { url "https://www.jetbrains.com/intellij-repository/snapshots" }
     maven { url "https://jetbrains.bintray.com/intellij-third-party-dependencies" }
 }
+
+compileJava.options.encoding = 'UTF-8'

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
 
       <p>This plugin extends the IDE’s folding features to emulate some of these modern languages’ features helping
         fight verbosity.</p>
-      
+
       <p>For more information, read the <a href="https://medium.com/@andrey_cheptsov/making-java-code-easier-to-read-without-changing-it-adeebd5c36de" target="_blank">blog post</a>.</p>
 
       <p>To get access to experimental features, go to <strong>Settings</strong> |
@@ -31,7 +31,7 @@
   <change-notes></change-notes>
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="145.0"/>
+  <idea-version since-build="193.0"/>
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
        on how to target different products -->

--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingHighlightingComponent.java
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingHighlightingComponent.java
@@ -203,7 +203,7 @@ public class AdvancedExpressionFoldingHighlightingComponent extends AbstractProj
     public void mouseClicked(EditorMouseEvent e) {
         if (e.getArea() == EditorMouseEventArea.EDITING_AREA) {
             @Nullable EditorEx editorEx = e.getEditor() instanceof EditorEx ? ((EditorEx) e.getEditor()) : null;
-            if (editorEx != null) {
+            if (editorEx != null && editorEx.getProject() == myProject) {
                 @NotNull VisualPosition visualPosition = editorEx.xyToVisualPosition(e.getMouseEvent().getPoint());
                 int offset = editorEx.logicalPositionToOffset(editorEx.visualToLogicalPosition(visualPosition));
                 try {
@@ -252,7 +252,7 @@ public class AdvancedExpressionFoldingHighlightingComponent extends AbstractProj
     public void mouseMoved(EditorMouseEvent e) {
         if (!DumbService.isDumb(myProject) && e.getArea() == EditorMouseEventArea.EDITING_AREA) {
             @Nullable EditorEx editorEx = e.getEditor() instanceof EditorEx ? ((EditorEx) e.getEditor()) : null;
-            if (editorEx != null) {
+            if (editorEx != null && editorEx.getProject() == myProject) {
                 @NotNull VisualPosition visualPosition = editorEx.xyToVisualPosition(e.getMouseEvent().getPoint());
                 int offset = editorEx.logicalPositionToOffset(editorEx.visualToLogicalPosition(visualPosition));
                 try {

--- a/src/com/intellij/advancedExpressionFolding/NumberLiteral.java
+++ b/src/com/intellij/advancedExpressionFolding/NumberLiteral.java
@@ -10,8 +10,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 
-import static sun.misc.FloatingDecimal.toJavaFormatString;
-
 public class NumberLiteral extends Expression implements ArithmeticExpression {
     private @NotNull Number number;
     private final boolean convert;
@@ -64,9 +62,9 @@ public class NumberLiteral extends Expression implements ArithmeticExpression {
             if (convert) {
                 descriptors.add(new FoldingDescriptor(element.getNode(), numberTextRange, group,
                         number instanceof Float ?
-                                toJavaFormatString(number.floatValue()) + "f":
+                                Float.toString(number.floatValue()) + "f":
                                 number instanceof Double ?
-                                        toJavaFormatString(number.doubleValue()) :
+                                        Double.toString(number.doubleValue()) :
                                         number.toString()));
             }
             if (numberTextRange.getEndOffset() < textRange.getEndOffset()) {


### PR DESCRIPTION
Also: fix Java 11 compilation, compatibility up to 212.*

Please note that while fresh versions have limited compatibility, 0.9.9.4 version is marked as 2016.1+ compatible (w/o until-build). So when the new IDEA version is released, people actually start using 0.9.9.4 because the latest plugin version is incompatible.

Probably it's good to remove all the versions prior to 0.9.9.4. Also, if the plugin support is on hiatus, probably it's better to remove until-build to let people using the plugin (at their own risk) in newer versions...